### PR TITLE
Fix initialize totalCount

### DIFF
--- a/jmorphy2-core/src/main/java/company/evo/jmorphy2/units/KnownSuffixUnit.java
+++ b/jmorphy2-core/src/main/java/company/evo/jmorphy2/units/KnownSuffixUnit.java
@@ -3,6 +3,7 @@ package company.evo.jmorphy2.units;
 import java.io.IOException;
 import java.lang.Math;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Iterator;
@@ -90,6 +91,7 @@ public class KnownSuffixUnit extends AnalyzerUnit {
         String[] paradigmPrefixes = dict.getParadigmPrefixes();
         int maxSuffixLength = Math.min(this.maxSuffixLength, wordLen);
         int[] totalCounts = new int[paradigmPrefixes.length];
+        Arrays.fill(totalCounts, 1);
         for (int prefixId = 0; prefixId < paradigmPrefixes.length; prefixId++) {
             String prefix = paradigmPrefixes[prefixId];
             if (!wordLower.startsWith(prefix)) {

--- a/jmorphy2-core/src/test/java/company/evo/jmorphy2/MorphAnalyzerTest.java
+++ b/jmorphy2-core/src/test/java/company/evo/jmorphy2/MorphAnalyzerTest.java
@@ -90,11 +90,11 @@ public class MorphAnalyzerTest {
                       morph.parse("шуруповертами"));
 
         // known suffix: with paradigm prefix
-        assertParseds("наиняшнейший:ADJF,Supr,Qual masc,sing,nomn:няшный:ейший:0.25\n" +
-                      "наиняшнейший:ADJF,Supr,Qual inan,masc,sing,accs:няшный:ейший:0.25\n" +
-                      "наиняшнейший:ADJF,Supr,Qual masc,sing,nomn:наиняшный:ейший:0.248387\n" +
-                      "наиняшнейший:ADJF,Supr,Qual inan,masc,sing,accs:наиняшный:ейший:0.248387\n" +
-                      "наиняшнейший:NOUN,anim,masc sing,nomn:наиняшнейший:ейший:0.003226\n",
+        assertParseds("наиняшнейший:ADJF,Supr,Qual masc,sing,nomn:наиняшный:ейший:0.252275\n" +
+                      "наиняшнейший:ADJF,Supr,Qual inan,masc,sing,accs:наиняшный:ейший:0.252275\n" +
+                      "наиняшнейший:ADJF,Supr,Qual masc,sing,nomn:няшный:ейший:0.246087\n" +
+                      "наиняшнейший:ADJF,Supr,Qual inan,masc,sing,accs:няшный:ейший:0.246087\n" +
+                      "наиняшнейший:NOUN,anim,masc sing,nomn:наиняшнейший:ейший:0.003276\n",
                       morph.parse("наиняшнейший"));
 
         // gen2, loct, loc2


### PR DESCRIPTION
Analyzing word with KnownSuffixUnit works incorrectly because of initialize `totalCount` array with 0 values. In pymorphy it is initialized with 1 values - [here](https://github.com/kmike/pymorphy2/blob/ca1c13f6998ae2d835bdd5033c17197dcba84cf4/pymorphy2/units/by_analogy.py#L196)